### PR TITLE
Change Travis CI url to link to impact2585. Fix bug where setSwerveSp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Cancer  
-[![Build Status](https://travis-ci.org/LoadingPleaseWait/Ophiuchus.svg?branch=master)](https://travis-ci.org/LoadingPleaseWait/Ophiuchus)  
+# Ophiuchus  
+[![Build Status](https://travis-ci.org/Impact2585/Ophiuchus.svg?branch=master)](https://travis-ci.org/Impact2585/Ophiuchus)  
 Team Impact's repository for VEX Starstruck

--- a/src/drivesystem.c
+++ b/src/drivesystem.c
@@ -5,11 +5,12 @@
 #include "../systems.h"
 #include "vex.h"
 #include "ch.h"
+#include <stdlib.h>
 
 static char* TASK_NAME = "drive";
 
 //true speed array
-const u32_t TrueSpeed[128] =
+const int16_t TrueSpeed[128] =
 {
   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
   0, 21, 21, 21, 22, 22, 22, 23, 24, 24,
@@ -30,10 +31,8 @@ const u32_t TrueSpeed[128] =
 void runDriveSystem() {
 	int16_t yAxis = vexControllerGet(Y_AXIS);
 	int16_t xAxis = vexControllerGet(X_AXIS);
-
-	motorDriveControlRight(sign(yAxis + xAxis)*TrueSpeed[abs(yAxis + xAxis)%127]);
-	motorDriveControlLeft(sign(yAxis - xAxis)*TrueSpeed[abs(yAxis - xAxis)%127]);
-	setSwerveMotorSpeed(xAxis);
+	motorDriveControlRight(sign(yAxis + xAxis)*TrueSpeed[abs(yAxis + xAxis) > 127 ? 127 : abs(yAxis + xAxis)]);
+	motorDriveControlLeft(sign(yAxis - xAxis)*TrueSpeed[abs(yAxis - xAxis) > 127  ? 127 : abs(yAxis - xAxis)]);
 }
 
 static WORKING_AREA(waDriveTask, DEFAULT_WA_SIZE);

--- a/src/shootersystem.c
+++ b/src/shootersystem.c
@@ -3,6 +3,7 @@
  */
 #include "../systems.h"
 #include "../ports.h"
+#include <stdlib.h>
 
 static char* SHOOT_TASK_NAME = "shoot";
 
@@ -12,9 +13,23 @@ void runShootTask(void) {
 
 	//moves forward then back
 	if(shouldShoot) {
-		rotateTowardsDegrees(100);
-		rotateTowardsDegrees(-100);
+		timedShoot();
 	}
+}
+
+//use timed shoot
+void timedShoot(void) {
+	setShootSpeeds(DEFAULT_SHOOTER_SPEED);
+	vexSleep(SHOOT_TIME);
+	setShootSpeeds(-DEFAULT_SHOOTER_SPEED);
+	vexSleep(SHOOT_TIME);
+	setShootSpeeds(0);
+}
+
+//use encoder values to shoot
+void encoderShoot(void) {
+	rotateTowardsDegrees(100);
+	rotateTowardsDegrees(-100);
 }
 
 //default working area of the thread size is 512 bytes
@@ -59,7 +74,7 @@ int16_t getShooterEncoderID(void) {
 void rotateTowardsDegrees(int32_t degrees) {
 	//starts the encoder
 	vexEncoderStart(getShooterEncoderID());
-	while((getShooterEncoderValue() < degrees) ^ (getShooterEncoderValue() > degrees)) {
+	while(abs(getShooterEncoderValue()) < abs(degrees)) {
 		setShootSpeeds(sign(degrees)* DEFAULT_SHOOTER_SPEED);
 	}
 	//sets the motor speeds back to 0

--- a/systems.h
+++ b/systems.h
@@ -25,6 +25,7 @@ void initializeDriveSystemThread(void);
 
 //shooter functions and constants
 #define DEFAULT_SHOOTER_SPEED 20
+#define SHOOT_TIME 200
 void initializeShootSystemThread(void);
 void setShootSpeeds(int16_t);
 void rotateTowardsDegrees(int32_t degrees);
@@ -36,6 +37,8 @@ int32_t getShooterEncoderValue(void);
 void runLiftTask(void);
 void initializeLiftSystemThread(void);
 void setLiftSpeed(int16_t speed);
+void timedShoot(void);
+void encoderShoot(void);
 
 //get sign of number for all types
 #define sign(x) ((x > 0) - (x < 0))


### PR DESCRIPTION
…eed was still being called in the drivesystem. Fix bug where the values weren't properly being set to 127 if the index of the TrueSpeed array was bigger than 127. Fix bug where the motor does not stop rotating if the encoder count received skips over the desired count. This closes #10 and #9.